### PR TITLE
fix: formatBirthDate bug

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -4,23 +4,25 @@ import { t } from "./i18n";
 import { isNumeric, padLeft } from "./util";
 
 /**
- * @param {import("./types").Locale} locale
  * @param {string|number} month
+ * @param {import("./types").Locale} locale
  * @return {string}
  */
-export const monthNameShort = (locale, month) => t("date.months.abbr." + month);
+export const monthNameShort = (month, locale) =>
+    t(locale, "date.months.abbr." + month);
 
 /**
  * @param {string} birthDay
  * @param {string} birthMonth
+ * @param {import("./types").Locale} locale
  * @return {string}
  */
-export const formatBirthDate = (birthDay, birthMonth) => {
+export const formatBirthDate = (birthDay, birthMonth, locale) => {
     const birthDayShort = isNumeric(birthDay)
         ? padLeft(birthDay, 2, "0")
         : birthDay;
     const birthMonthShort = isNumeric(birthMonth)
-        ? monthNameShort(birthMonth)
+        ? monthNameShort(birthMonth, locale)
         : birthMonth;
     return birthDayShort + " " + birthMonthShort;
 };

--- a/src/proofs.js
+++ b/src/proofs.js
@@ -52,7 +52,8 @@ const domesticProof = (data) => {
 
         birthDateStringShort: formatBirthDate(
             data.attributes.birthDay,
-            data.attributes.birthMonth
+            data.attributes.birthMonth,
+            "nl"
         ),
 
         validFromDate,

--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,4 @@
-const NUM = /^\d+&/;
+const NUM = /^\d+$/;
 
 /**
  * @param {string} input


### PR DESCRIPTION
Fix for a regression that causes domestic birth day to be formatted as e.g. `"1 5"` instead of e.g. `"01 MEI"`.
