### PR TITLE
fix: month abbreviation locale in domestic proof

### DIFF
--- a/src/proofs.js
+++ b/src/proofs.js
@@ -11,14 +11,15 @@ import {
  * TODO any type
  * @param {import("./types").ProofData} proofData
  * @param {any} holderConfig
+ * @param {import("./types").Locale} [locale]
  * @return {import("./types").Proof[]}
  */
-export const parseProofData = (proofData, holderConfig) => {
+export const parseProofData = (proofData, holderConfig, locale) => {
     /** @type {import("./types").Proof[]} */
     const proofs = [];
 
     if (proofData.domestic) {
-        proofs.push(domesticProof(proofData.domestic));
+        proofs.push(domesticProof(proofData.domestic, locale));
     }
     if (proofData.european) {
         for (const proof of europeanProofs(proofData.european, holderConfig)) {
@@ -31,9 +32,10 @@ export const parseProofData = (proofData, holderConfig) => {
 
 /**
  * @param {import("./types").DomesticProofData} data
+ * @param {import("./types").Locale} [locale]
  * @return {import("./types").Proof}
  */
-const domesticProof = (data) => {
+const domesticProof = (data, locale) => {
     const validFromDate = parseInt(data.attributes.validFrom, 10) * 1000;
     return {
         proofType: "domestic",
@@ -53,7 +55,7 @@ const domesticProof = (data) => {
         birthDateStringShort: formatBirthDate(
             data.attributes.birthDay,
             data.attributes.birthMonth,
-            "nl"
+            locale || "nl"
         ),
 
         validFromDate,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "include": ["src/**/*"],
   "compilerOptions": {
-    "allowJs": false,
-    "checkJs": false,
+    "allowJs": true,
+    "checkJs": true,
     "declaration": true,
     "emitDeclarationOnly": true,
     "moduleResolution": "node",

--- a/types/date.d.ts
+++ b/types/date.d.ts
@@ -1,5 +1,5 @@
-export function monthNameShort(locale: import("./types").Locale, month: string | number): string;
-export function formatBirthDate(birthDay: string, birthMonth: string): string;
+export function monthNameShort(month: string | number, locale: import("./types").Locale): string;
+export function formatBirthDate(birthDay: string, birthMonth: string, locale: import("./types").Locale): string;
 export function formatDate(dateTimeMs: number | Date): string;
 export function formatDateTime(dateTimeMs: number | Date): string;
 export function hoursInMs(hours: string): number;

--- a/types/proofs.d.ts
+++ b/types/proofs.d.ts
@@ -1,1 +1,1 @@
-export function parseProofData(proofData: import("./types").ProofData, holderConfig: any): import("./types").Proof[];
+export function parseProofData(proofData: import("./types").ProofData, holderConfig: any, locale?: import("./types").Locale): import("./types").Proof[];


### PR DESCRIPTION
Add an optional `locale` param to `parseProofData`. Closes #13.