### PR TITLE
fix: avoid UCI "falling off the page"

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -238,7 +238,7 @@ const getUserDetails = (proof, locale) => {
         const fontSizeSmallCaps = 6;
         const fontSizeTinyCaps = 5;
         const lineHeightSmallCaps = fontSizeSmallCaps * 0.5;
-        const fieldSpacing = lineHeightSmallCaps * 3;
+        const fieldSpacing = lineHeightSmallCaps * 2.5;
         const fields = ["name", "dateOfBirth"];
         const values = [proof.fullName, proof.birthDateString];
         switch (proof.eventType) {


### PR DESCRIPTION
Reduce the EU `fieldSpacing` by 1/6th to avoid the UCI "falling off the page".

Before|After
--|--
![Screenshot_20210707_091947](https://user-images.githubusercontent.com/67802/124716578-8938db00-df04-11eb-9c06-45c52ef9339f.png)|![Screenshot_20210707_092005](https://user-images.githubusercontent.com/67802/124716582-8b029e80-df04-11eb-8c62-595bc4d489d6.png)

