### PR TITLE
fix: filter for text with a null

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -196,7 +196,7 @@ export const getTextItems = (proof, locale) => {
             }
         );
     }
-    return items;
+    return items.filter((item) => item.text !== null);
 };
 
 /**


### PR DESCRIPTION
When feeding `doc.splitTextToSize()` with a `null`, jspdf will turn this into the string `'null'`