### PR TITLE
feat: format datetimes in user timezone

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -1,7 +1,7 @@
 import * as img from "./assets/img";
 import { generateQR } from "./qr";
 import { t } from "./i18n";
-import { formatTimestamp } from "./date";
+import { formatDateTime } from "./date";
 
 /** @typedef {import("./types").Proof} Proof */
 /** @typedef {import("./types").Locale} Locale */
@@ -137,7 +137,7 @@ export const getTextItems = (proof, locale, createdAt) => {
     if (proof.territory === "eu") {
         items.push({
             text: t(locale, "eu.warning", {
-                time: formatTimestamp(createdAt),
+                time: formatDateTime(createdAt),
             }),
             fontFamily: "roboto",
             fontWeight: 400,

--- a/src/content.js
+++ b/src/content.js
@@ -1,7 +1,7 @@
 import * as img from "./assets/img";
 import { generateQR } from "./qr";
 import { t } from "./i18n";
-import { getCurrentDateTime } from "./date";
+import { formatTimestamp } from "./date";
 
 /** @typedef {import("./types").Proof} Proof */
 /** @typedef {import("./types").Locale} Locale */
@@ -64,9 +64,10 @@ export const lineHeight = 4.5;
 /**
  * @param {Proof} proof
  * @param {Locale} locale
+ * @param {Date|number} createdAt
  * @return {TextItem[]}
  */
-export const getTextItems = (proof, locale) => {
+export const getTextItems = (proof, locale, createdAt) => {
     /** @type {TextItem[]} */
     const items = [
         {
@@ -136,7 +137,7 @@ export const getTextItems = (proof, locale) => {
     if (proof.territory === "eu") {
         items.push({
             text: t(locale, "eu.warning", {
-                time: getCurrentDateTime(),
+                time: formatTimestamp(createdAt),
             }),
             fontFamily: "roboto",
             fontWeight: 400,

--- a/src/date.js
+++ b/src/date.js
@@ -46,6 +46,7 @@ const formatter =
         day: "2-digit",
         hour: "2-digit",
         minute: "2-digit",
+        second: "2-digit",
         timeZoneName: "short",
     });
 

--- a/src/date.js
+++ b/src/date.js
@@ -56,30 +56,7 @@ export const formatDateTime = (isoDateString) => {
 const pad = (n) => (n < 10 ? "0" + n : "" + n);
 
 /**
- * @return {string}
- */
-export const getCurrentDateTime = () => {
-    const date = new Date();
-    return (
-        date.getDate() +
-        "-" +
-        (date.getMonth() + 1) +
-        "-" +
-        date.getFullYear() +
-        ", " +
-        pad(date.getHours()) +
-        ":" +
-        pad(date.getMinutes()) +
-        ":" +
-        pad(date.getSeconds()) +
-        " (" +
-        formatOffset(date.getTimezoneOffset()) +
-        ")"
-    );
-};
-
-/**
- * @param {number} timestampMs
+ * @param {Date|number} timestampMs
  * @return {string}
  */
 export const formatTimestamp = (timestampMs) => {

--- a/src/date.test.js
+++ b/src/date.test.js
@@ -30,27 +30,8 @@ describe("formatDate", () => {
     });
 });
 
-describe("formatDateTime", () => {
-    test.each([
-        ["1970-01-01", "01-01-1970"],
-        ["2021-07-27T07:41:10", "27-07-2021, 07:41"],
-        ["2021-07-27T07:41:10Z", "27-07-2021, 07:41 (UTC)"],
-        ["2021-07-27T07:41:10+00:00", "27-07-2021, 07:41 (UTC)"],
-        ["2021-07-27T09:41:10+02:00", "27-07-2021, 09:41 (UTC+02:00)"],
-        ["2021-07-27T09:41:10.1234+02:00", "27-07-2021, 09:41 (UTC+02:00)"],
-        ["2021-07-27T04:41:10-3", "27-07-2021, 04:41 (UTC-3)"],
-        ["2021-12-31T13:37Z", "31-12-2021, 13:37 (UTC)"],
-        ["12/31/2020", "12/31/2020"],
-        ["1970-XX-XX", "XX-XX-1970"],
-        ["yesterday", "yesterday"],
-        ["", ""],
-    ])("%j => %j", (input, expected) => {
-        expect(formatDateTime(input)).toBe(expected);
-    });
-});
-
 // TODO: run tests in specific timezone? (won't work on Windows)
-test.todo("formatTimestamp");
+test.todo("formatDateTime");
 
 describe("hoursInMs", () => {
     test.each([

--- a/src/date.test.js
+++ b/src/date.test.js
@@ -51,7 +51,6 @@ describe("formatDateTime", () => {
 
 // TODO: run tests in specific timezone? (won't work on Windows)
 test.todo("formatTimestamp");
-test.todo("getCurrentDateTime");
 
 describe("hoursInMs", () => {
     test.each([

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -21,7 +21,7 @@ export default {
     "nl.intro":
         "Visiting locations or activities within the Netherlands? Then use this certificate.",
     "eu.warning":
-        "This certificate is not a travel document. The scientific evidence regarding COVID-19 vaccinations, testing and recovery continues to evolve, also with regard to new variants of concern. Before traveling, please check which public health measures and associated restrictions apply at the destination.\n\nPRINTED ON %{time}",
+        "This certificate is not a travel document. The scientific evidence regarding COVID-19 vaccinations, testing and recovery continues to evolve, also with regard to new variants of concern. Before traveling, please check which public health measures and associated restrictions apply at the destination.\n\nCreated at %{time}",
     "eu.userData.name": "SURNAME(S) AND FIRST NAME(S)",
     "eu.userData.dateOfBirth": "Date of birth (DD-MM-YYYY)",
     "eu.userData.disease": "DISEASE TARGETED",

--- a/src/i18n/nl.js
+++ b/src/i18n/nl.js
@@ -14,7 +14,7 @@ export default {
     "eu.intro":
         "Reis je buiten Nederland? Gebruik dan dit EU Digitaal Corona Certificaat (DCC).\n\nBekijk voor vertrek welke test-, herstel- of vaccinatiebewijzen geldig zijn in het land dat je bezoekt: https://reopen.europa.eu/nl",
     "eu.warning":
-        "Dit certificaat is geen reisdocument. Het wetenschappelijk bewijs met betrekking tot COVID-19-vaccinaties, -tests en -herstel blijft zich verder ontwikkelen, ook met betrekking tot nieuwe zorgwekkende varianten. Gelieve alvorens een reis te maken, te controleren welke volksgezondheidsmaatregelen en bijbehorende beperkingen op de plaats van bestemming van toepassing zijn.\n\nGEPRINT OP / PRINTED ON %{time}",
+        "Dit certificaat is geen reisdocument. Het wetenschappelijk bewijs met betrekking tot COVID-19-vaccinaties, -tests en -herstel blijft zich verder ontwikkelen, ook met betrekking tot nieuwe zorgwekkende varianten. Gelieve alvorens een reis te maken, te controleren welke volksgezondheidsmaatregelen en bijbehorende beperkingen op de plaats van bestemming van toepassing zijn.\n\nGemaakt op / created at %{time}",
     "eu.userData.name": "ACHTERNAAM EN VOORNAM(EN)",
     "eu.userData.dateOfBirth": "Geboortedatum",
     "eu.userData.disease": "Ziekteverwekker",

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -153,22 +153,27 @@ const drawFrames = (doc, frames) => {
 };
 
 /**
- * @param {Proof[]} proofs
- * @param {"en"|"nl"} locale
- * @param {number} qrSizeInCm
- * @param {Metadata} [metadata]
+ * @param {Object} args
+ * @param {Proof[]} args.proofs
+ * @param {"en"|"nl"} args.locale
+ * @param {number} args.qrSizeInCm
+ * @param {Date|number} args.createdAt - Date or timestamp in ms
+ * @param {Metadata} [args.metadata]
  * @return {Promise<jsPDF>}
  */
-export const getDocument = async (proofs, locale, qrSizeInCm, metadata) => {
-    const doc = initDoc(locale, metadata);
-    for (const proof of proofs) {
-        if (proofs.indexOf(proof) > 0) {
+export const getDocument = async (args) => {
+    if (args.createdAt instanceof Date && isNaN(args.createdAt.getTime())) {
+        throw new Error("Invalid createdAt");
+    }
+    const doc = initDoc(args.locale, args.metadata);
+    for (const proof of args.proofs) {
+        if (args.proofs.indexOf(proof) > 0) {
             doc.addPage();
         }
         const frames = getFrames(proof.territory);
-        const textItems = getTextItems(proof, locale);
+        const textItems = getTextItems(proof, args.locale, args.createdAt);
         const lines = getLines();
-        const imageItems = await getImageItems(proof, qrSizeInCm);
+        const imageItems = await getImageItems(proof, args.qrSizeInCm);
         drawFrames(doc, frames);
         drawImageItems(doc, imageItems);
         drawLines(doc, lines);

--- a/src/proofs.js
+++ b/src/proofs.js
@@ -2,7 +2,6 @@ import {
     formatBirthDate,
     formatDate,
     formatDateTime,
-    formatTimestamp,
     hoursInMs,
 } from "./date";
 import {
@@ -65,9 +64,9 @@ const domesticProof = (data, locale) => {
 
         validFromDate,
 
-        validFrom: formatTimestamp(validFromDate),
+        validFrom: formatDateTime(validFromDate),
 
-        validUntil: formatTimestamp(
+        validUntil: formatDateTime(
             validFromDate + hoursInMs(data.attributes.validForHours)
         ),
     };


### PR DESCRIPTION
Ticket: [coronacheck-4/us/1157](https://taiga.rdobeheer.nl/project/coronacheck-4/us/1157)

Firefox 89 | Edge 91 (Windows 10)
--|--
![Screenshot_20210715_150743](https://user-images.githubusercontent.com/67802/125793275-866821a1-1b97-426f-b45c-75c3d48979c1.png)|![Screenshot_20210715_150610](https://user-images.githubusercontent.com/67802/125793144-723ddf93-8ca2-4318-b1c3-312702bd7746.png)


BREAKING: getDocument now takes a single `args` parameter, and now requires a createdAt datetime. To update, change e.g. `getDocument(proofs, 'nl', 8)` to `getDocument({ proofs, locale: 'nl', qrSizeInCm: 8, createdAt: new Date(createdAt) })`.
