### PR TITLE
fix: single-dose-and-recovery

### DIFF
--- a/src/pdf/dccCoverPage.js
+++ b/src/pdf/dccCoverPage.js
@@ -202,7 +202,7 @@ function proofsList(doc, proofs) {
         if (isRecovery(proof)) {
             return t(doc.locale, "cover.recoveryProof");
         }
-        return t(doc.local, "cover.otherProof");
+        return t(doc.locale, "cover.otherProof");
     });
 
     var proofsList = doc._pdf.struct("L", function () {

--- a/src/pdf/dccCoverPage.js
+++ b/src/pdf/dccCoverPage.js
@@ -200,7 +200,7 @@ function proofsList(doc, proofs) {
             );
         }
         if (isRecovery(proof)) {
-            return t(doc.local, "cover.recoveryProof");
+            return t(doc.locale, "cover.recoveryProof");
         }
         return t(doc.local, "cover.otherProof");
     });

--- a/src/proof/status.js
+++ b/src/proof/status.js
@@ -58,7 +58,7 @@ function byDoseNumber(a, b) {
  * @return {proof is import("../types").EuropeanProof}
  */
 function isEuropeanProof(proof) {
-    return proof.territory === "eu" && proof.eventType === "vaccination";
+    return proof.territory === "eu";
 }
 
 /**

--- a/test/single-dose-and-recovery.json
+++ b/test/single-dose-and-recovery.json
@@ -1,0 +1,62 @@
+{
+    "domestic": null,
+    "european": [
+        {
+            "expirationTime": "2022-12-02T10:00:21+00:00",
+            "dcc": {
+                "ver": "1.3.0",
+                "nam": {
+                    "fn": "van Geer",
+                    "fnt": "VAN<GEER",
+                    "gn": "Corrie",
+                    "gnt": "CORRIE"
+                },
+                "dob": "1960-01-01",
+                "v": [
+                    {
+                        "tg": "840539006",
+                        "ci": "URN:UCI:01:NL:432YWERBYBH23G2RFUYX42#L",
+                        "co": "NL",
+                        "is": "Ministry of Health Welfare and Sport",
+                        "vp": "1119349007",
+                        "mp": "EU/1/20/1528",
+                        "ma": "ORG-100030215",
+                        "dn": 1,
+                        "sd": 2,
+                        "dt": "2021-10-27"
+                    }
+                ],
+                "t": null,
+                "r": null
+            },
+            "qr": "HC1:NCFC20490T9WTWGVLK-49NJ3B0J$OCC*AX*4FBBU42*70J+9DN03E53F36ELZW6Y50.FK8ZKO/EZKEZ967L6C56GVC*JC1A6C%63W5Y96746TPCBEC7ZKW.CC9DCECS34$ CXKEW.CAWEV+A3+9K09GY8 JC2/DSN83LEQEDMPCG/DY-CB1A5IAVY87:EDOL9WEQDD+Q6TW6FA7C466KCN9E%961A6DL6FA7D46.JCP9EJY8L/5M/5546.96VF6.JCBECB1A-:8$966469L6OF6VX6FVC*70KQEPD0LVC6JD846Y96$965W5307UPCBJCOT9+EDL8FHZ95/D QEALEN44:+C%69AECAWE:34: CJ.CZKE9440/D+34S9E5LEWJC0FD3%4AIA%G7ZM81G72A6J+95G7BL6BDBGY8KH83H8QF61092IAOZAZ6BAF6ET9O58ZXP%ZTE8O9*6T*JHINMKUFPMR9TL:5%3D/XOT6R889J S6BA7NFG2B/+OS 57$3$56IIEC2MZE43UAWG3%9B.WSWFLH8I0U3000FGWSOP+TF"
+        },
+        {
+            "expirationTime": "2022-05-02T00:00:00+00:00",
+            "dcc": {
+                "ver": "1.3.0",
+                "nam": {
+                    "fn": "van Geer",
+                    "fnt": "VAN<GEER",
+                    "gn": "Corrie",
+                    "gnt": "CORRIE"
+                },
+                "dob": "1960-01-01",
+                "v": null,
+                "t": null,
+                "r": [
+                    {
+                        "tg": "840539006",
+                        "ci": "URN:UCI:01:NL:U3WBZBDHXFCLZHMEEW3R42#J",
+                        "co": "NL",
+                        "is": "Ministry of Health Welfare and Sport",
+                        "fr": "2021-11-03",
+                        "df": "2021-11-14",
+                        "du": "2022-05-02"
+                    }
+                ]
+            },
+            "qr": "HC1:NCF%RN%TS3DH0RGPJB/IB-OM7533SRQCH9M9*VIHWF S4KHRFE2V P--M:UC*GP-S4FT5D75W9AAABE34+V4YC5/HQ/ PHCR+9AFDOEA7IB65C94JB9+81LCDMGHKDFDA4JB%B9FDJU7KSWNMPD9JA8/B1RERCAS.CBLEH-B3PJC4G-CI+PD%FAGUU0QIRR97I2HOAXL92L0: KQMK8J4RK4PZBAN85M02%KI*V.18N$K-PSJY2W*PP+P8OI.I9Y*VSV0I+QWZJAQ12KUL JS%O$UA9*OXQ29HS9.VAOI5XI1ENJO8C K%GA99QHCRTWA7DON95ZTM7W5HHPTI58ORJSPZHQ1CQTI5L87XC5%MPJN421QG155YO-.Q $R6HPJ99.N5.E85TH*BRQWSMFBONRE%I137L*8V:4S$7C8DQDNIDVZJLDWV-QRRWI2/QH4U0226K71IU73BIOPINH4A1LATL81KFF2CSFHN-HOQIB448000FGW.N7QTE"
+        }
+    ]
+}


### PR DESCRIPTION
This fixes a bug in `getEuropeanProofs`, which would cause the DCC cover page from providing incorrect `proofs` list to `getVaccinationStatus` and erroneously concluding that the cover page was unneeded.