### PR TITLE
fix: eu details section throws on null value

### DIFF
--- a/src/pdf/struct.js
+++ b/src/pdf/struct.js
@@ -51,8 +51,8 @@ export function structText(doc, type, textItem) {
     var lineGap = textItem.lineGap && textItem.lineGap * dpmm;
     var parts =
         textItem.parseLinks === false
-            ? [textItem.text]
-            : parseMarkdownLinks(textItem.text);
+            ? [textItem.text || ""]
+            : parseMarkdownLinks(textItem.text || "");
     var after;
     if (textItem.emptyLineAfter) {
         after = function (i) {


### PR DESCRIPTION
Fix a regression introduced by 34421ab (#52), which causes `addProofPage` to throw when one of the DCC's values is `null`.
