### PR TITLE
feat: add optional footer to NL proof (issued on, key identifier)

### DIFF
--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -55,6 +55,8 @@ export default {
     "nl.userData.validFrom": "Valid from",
     "nl.userData.validUntil": "Valid until",
     "nl.userData.privacyNote": "You can keep your details to yourself",
+    "nl.issuedOn": "Issued on %{date}",
+    "nl.keyId": "Key identifier: %{keyId}",
     instructions: "Instructions",
     "alt.foldInstructions":
         "Folding instructions. First fold in half widthwise, with the printed side out. Then fold in half again with these instructions on the inside.",

--- a/src/i18n/nl.js
+++ b/src/i18n/nl.js
@@ -55,6 +55,8 @@ export default {
     "nl.userData.validUntil": "Geldig tot",
     "nl.userData.privacyNote":
         "Bovenstaande gegevens hoef je niet te laten zien bij de ingang.",
+    "nl.issuedOn": "Uitgegeven op %{date}",
+    "nl.keyId": "Sleutelnummer: %{keyId}",
     instructions: "Instructies",
     "alt.foldInstructions":
         "Vouwinstructies. Vouw eerst in de breedte doormidden, met de geprinte kant naar buiten. Vouw daarna opnieuw doormidden met deze instructies aan de binnenzijde.",

--- a/src/pdf/document.js
+++ b/src/pdf/document.js
@@ -140,6 +140,8 @@ export function createDocument(locale, args) {
  * @param {import("../types").Proof[]} args.proofs
  * @param {"en"|"nl"} args.locale
  * @param {Date|number} args.createdAt - Date or timestamp in ms
+ * @param {boolean} [args.nlPrintIssuedOn] - Include "issued on" footer on NL proof (default false).
+ * @param {string} [args.nlKeyId] - If provided, include in footer on NL proof.
  * @param {string} [args.title]
  * @param {string} [args.author]
  * @param {number} [args.qrSizeInCm] DEPRECATED
@@ -158,8 +160,12 @@ export function getDocument(args) {
         createdAt: args.createdAt,
     });
     addDccCoverPage(doc, args.proofs, args.createdAt);
+    var proofArgs = {
+        nlPrintIssuedOn: args.nlPrintIssuedOn || false,
+        nlKeyId: args.nlKeyId,
+    };
     args.proofs.forEach(function (proof) {
-        addProofPage(doc, proof, args.createdAt);
+        addProofPage(doc, proof, args.createdAt, proofArgs);
     });
     return documentToBlob(doc).then(function (blob) {
         return blobToDataURI(blob).then(function (dataURI) {


### PR DESCRIPTION
Add a footer to the NL proof page with "issued on" and "key identifier" metadata (both optional).
