### PR TITLE
feat: key identifier, validity explanation and footer

### DIFF
--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -19,7 +19,8 @@ export default {
     "eu.qrTitle": "International QR-code",
     "nl.instructions":
         "Print this certificate on A4 (black-and-white allowed)\n\nBring a valid proof of identity to the activity you’re visiting \n\nShow the certificate and the proof of identity (and if needed a ticket) at the entrance",
-    "nl.propertiesLabel": "Details",
+    "nl.propertiesLabel": "Your credentials:",
+    "nl.validityLabel": "Certificate validity:",
     "nl.title": "Certificate for the Netherlands",
     "nl.intro":
         "Visiting locations or activities within the Netherlands? Then use this certificate.",
@@ -50,13 +51,14 @@ export default {
     "eu.userData.validUntil": "Valid to",
     "eu.userData.certificateNumber": "UNIQUE CERTIFICATE IDENTIFIER",
     "nl.qrTitle": "Coronavirus pass",
-    "nl.userData.initials": "Initials",
-    "nl.userData.dateOfBirth": "Day of birth",
-    "nl.userData.validFrom": "Valid from",
-    "nl.userData.validUntil": "Valid until",
-    "nl.userData.privacyNote": "You can keep your details to yourself",
-    "nl.issuedOn": "Issued on %{date}",
+    "nl.userData": "Initials: %{initials}\nDay of birth: %{dateOfBirth}",
+    "nl.validityDetails":
+        "Valid from: %{validFrom}\nValid until: %{validUntil}",
+    "nl.issuedOn": "Printed on %{date}",
     "nl.keyId": "Key identifier: %{keyId}",
+    "nl.maxValidityExplanation":
+        "* This paper certificate is valid for a maximum of %{days} days. After this you can print a new certificate via [coronacheck.nl/print](https://coronacheck.nl/print) (as long as your vaccination or recovery is still valid). For more information on the requirements and validity of certificates, please visit [rijksoverheid.nl/coronabewijs](https://rijksoverheid.nl/coronabewijs).",
+    "nl.maxValidity": "Valid for a maximum of %{days} days*",
     instructions: "Instructions",
     "alt.foldInstructions":
         "Folding instructions. First fold in half widthwise, with the printed side out. Then fold in half again with these instructions on the inside.",

--- a/src/i18n/nl.js
+++ b/src/i18n/nl.js
@@ -56,7 +56,7 @@ export default {
     "nl.issuedOn": "Geprint op %{date}",
     "nl.keyId": "Sleutelnummer: %{keyId}",
     "nl.maxValidityExplanation":
-        "Dit papieren bewijs is maximaal %{days} dagen geldig. Hierna kun je een nieuw bewijs printen via [coronacheck.nl/print](https://coronacheck.nl/print) (zolang je vaccinatie of herstel nog geldig is). Kijk op [rijksoverheid.nl/coronabewijs](https://rijksoverheid.nl/coronabewijs) voor meer informatie over de eisen en geldigheid van coronabewijzen.",
+        "* Dit papieren bewijs is maximaal %{days} dagen geldig. Hierna kun je een nieuw bewijs printen via [coronacheck.nl/print](https://coronacheck.nl/print) (zolang je vaccinatie of herstel nog geldig is). Kijk op [rijksoverheid.nl/coronabewijs](https://rijksoverheid.nl/coronabewijs) voor meer informatie over de eisen en geldigheid van coronabewijzen.",
     "nl.maxValidity": "Maixmaal %{days} dagen geldig*",
     instructions: "Instructies",
     "alt.foldInstructions":

--- a/src/i18n/nl.js
+++ b/src/i18n/nl.js
@@ -43,20 +43,21 @@ export default {
     "eu.userData.certificateNumber": "UNIEK CERTIFICAATNUMMER",
     "nl.instructions":
         "Print dit coronabewijs op A4 (mag in zwart-wit)\n\nNeem een geldig identiteitsbewijs mee naar de activiteit\n\nLaat je coronabewijs en je identiteitsbewijs (en eventueel ook je toegangskaartje) zien bij de ingang",
-    "nl.propertiesLabel": "Gegevens",
+    "nl.propertiesLabel": "Jouw gegevens:",
+    "nl.validityLabel": "Geldigheid bewijs:",
     "nl.title": "Bewijs voor in Nederland",
     "nl.intro":
         "Bezoek je locaties of activiteiten binnen Nederland? Gebruik dan dit coronabewijs.",
     "nl.alt.flag": "Nederlandse vlag",
     "nl.qrTitle": "Coronatoegangs-\nbewijs",
-    "nl.userData.initials": "Initialen",
-    "nl.userData.dateOfBirth": "Geboortedag",
-    "nl.userData.validFrom": "Geldig vanaf",
-    "nl.userData.validUntil": "Geldig tot",
-    "nl.userData.privacyNote":
-        "Bovenstaande gegevens hoef je niet te laten zien bij de ingang.",
-    "nl.issuedOn": "Uitgegeven op %{date}",
+    "nl.userData": "Initialen: %{initials}\nGeboortedag: %{dateOfBirth}",
+    "nl.validityDetails":
+        "Geldig vanaf: %{validFrom}\nGeldig tot: %{validUntil}",
+    "nl.issuedOn": "Geprint op %{date}",
     "nl.keyId": "Sleutelnummer: %{keyId}",
+    "nl.maxValidityExplanation":
+        "Dit papieren bewijs is maximaal %{days} dagen geldig. Hierna kun je een nieuw bewijs printen via [coronacheck.nl/print](https://coronacheck.nl/print) (zolang je vaccinatie of herstel nog geldig is). Kijk op [rijksoverheid.nl/coronabewijs](https://rijksoverheid.nl/coronabewijs) voor meer informatie over de eisen en geldigheid van coronabewijzen.",
+    "nl.maxValidity": "Maixmaal %{days} dagen geldig*",
     instructions: "Instructies",
     "alt.foldInstructions":
         "Vouwinstructies. Vouw eerst in de breedte doormidden, met de geprinte kant naar buiten. Vouw daarna opnieuw doormidden met deze instructies aan de binnenzijde.",

--- a/src/pdf/document.js
+++ b/src/pdf/document.js
@@ -140,14 +140,14 @@ export function createDocument(locale, args) {
  * @param {import("../types").Proof[]} args.proofs
  * @param {"en"|"nl"} args.locale
  * @param {Date|number} args.createdAt - Date or timestamp in ms
- * @param {boolean} [args.nlPrintIssuedOn] - Include "issued on" footer on NL proof (default false).
- * @param {string} [args.nlKeyId] - If provided, include in footer on NL proof.
  * @param {string} [args.title]
  * @param {string} [args.author]
  * @param {number} [args.qrSizeInCm] DEPRECATED
  * @param {Object} [args.metadata] DEPRECATED
  * @param {string} [args.metadata.title] DEPRECATED
  * @param {string} [args.metadata.author] DEPRECATED
+ * @param {boolean} [args.nlPrintIssuedOn] DEPRECATED
+ * @param {string} [args.nlKeyId] DEPRECATED
  * @return {Promise<LegacyDocument>}
  */
 export function getDocument(args) {
@@ -160,12 +160,8 @@ export function getDocument(args) {
         createdAt: args.createdAt,
     });
     addDccCoverPage(doc, args.proofs, args.createdAt);
-    var proofArgs = {
-        nlPrintIssuedOn: args.nlPrintIssuedOn || false,
-        nlKeyId: args.nlKeyId,
-    };
     args.proofs.forEach(function (proof) {
-        addProofPage(doc, proof, args.createdAt, proofArgs);
+        addProofPage(doc, proof, args.createdAt);
     });
     return documentToBlob(doc).then(function (blob) {
         return blobToDataURI(blob).then(function (dataURI) {

--- a/src/pdf/draw.js
+++ b/src/pdf/draw.js
@@ -135,12 +135,13 @@ export function drawBackgroundArtifact(
     y,
     width,
     height,
-    cornerRadius = 4
+    cornerRadius = 4,
+    color = "#f0f7fa"
 ) {
     cornerRadius = cornerRadius * dpmm;
     doc.pdf.markContent("Artifact", { type: "Layout" });
     doc.pdf
-        .fillColor("#f0f7fa")
+        .fillColor(color)
         .roundedRect(
             x * dpmm,
             y * dpmm,

--- a/src/pdf/proofPage.js
+++ b/src/pdf/proofPage.js
@@ -117,7 +117,7 @@ function structNlProof(doc, qrSvg, proof, createdAt) {
         doc.pdf.struct("Sect", proofContent),
     ];
 
-    if (proof.keyIdentifier) {
+    if (proof.keyIdentifier && !proof.validAtMost25Hours) {
         content.push(structNlFooter(doc));
     }
 

--- a/src/pdf/proofPage.js
+++ b/src/pdf/proofPage.js
@@ -69,6 +69,7 @@ var fontSizeFooter = 8;
  * args.nlPrintIssuedOn and args.nlKeyId are DEPRECATED
  */
 export function addProofPage(doc, proof, createdAt) {
+    var structProof = proof.territory === "nl" ? structNlProof : structEuProof;
     doc.addPart(function () {
         return qrDataToSvg(
             proof.qr,
@@ -88,9 +89,7 @@ export function addProofPage(doc, proof, createdAt) {
             doc.loadFont("ROSansBold", ROSansWebTextBold);
             doc.addStruct("Art", [
                 structLogoRijksoverheid(doc),
-                proof.territory === "nl"
-                    ? structNlProof(doc, qrSvg, proof, createdAt)
-                    : structEuProof(doc, qrSvg, proof, createdAt),
+                structProof(doc, qrSvg, proof, createdAt),
             ]);
         });
     });

--- a/src/proof/details.js
+++ b/src/proof/details.js
@@ -1,16 +1,8 @@
 /**
- * @param {import("../types").Proof} proof
+ * @param {import("../types").EuropeanProof} proof
  * @return {string[][]}
  */
 export function getProofDetails(proof) {
-    if (proof.territory === "nl") {
-        return [
-            ["initials", proof.initials],
-            ["dateOfBirth", proof.birthDateStringShort],
-            ["validFrom", proof.validFrom],
-            ["validUntil", proof.validUntil],
-        ];
-    }
     if (proof.eventType === "vaccination") {
         return [
             ["name", proof.fullName],

--- a/src/proof/parse.js
+++ b/src/proof/parse.js
@@ -69,6 +69,10 @@ export function parseDomesticProof(data, locale) {
         validUntil: formatLocalDateTime(
             validFromDate + hoursInMs(data.attributes.validForHours)
         ),
+
+        keyIdentifier: data.keyIdentifier || null,
+
+        validAtMost25Hours: parseInt(data.attributes.validForHours, 10) <= 25,
     };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,8 @@ export type DomesticProofData = {
         birthMonth: string; // e.g. "5"
     };
     qr: string;
+    proofIdentifier: string;
+    keyIdentifier?: string | null;
 };
 
 export type EuropeanProofData = {
@@ -55,6 +57,8 @@ export type EuropeanProofData = {
         r: RecoveryCredential[] | null;
     };
     qr: string;
+    proofIdentifier: string;
+    keyIdentifier?: string | null;
 };
 
 type BaseCredentials = {
@@ -96,6 +100,8 @@ type DomesticProof = {
     birthDateStringShort: string;
     validFrom: string;
     validUntil: string;
+    keyIdentifier: string | null;
+    validAtMost25Hours?: boolean;
 };
 
 export type EuropeanProof =


### PR DESCRIPTION
Add new validity explanation and footer for domestic proofs. Both are omitted if the `domestic` does not have a `keyIdentifier`. The explanation is omitted, as well as the text on the footer (but not the footer itself) if the `domestic`'s `validForHours` is less than or equal to `25`.

This deprecates the `nlPrintIssuedOn` and `nlKeyId` arguments to `getDocument`.