### PR TITLE
fix: various domestic proof mistakes

### DIFF
--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -17,8 +17,12 @@ export default {
         "Are you abroad or crossing the border? Then use this EU Digital Corona Certificate (DCC). Before leaving, please check which certificate you need at your destination at: [netherlandsworldwide.nl](https://netherlandsworldwide.nl).",
     "eu.alt.flag": "Flag of the European Union with the letters NL on it",
     "eu.qrTitle": "International QR-code",
-    "nl.instructions":
+    "nl.instructions.test":
+        "Make sure this certificate is printed on A4 (black-and-white allowed)\n\nBring a valid proof of identity to the activity you’re visiting \n\nShow the certificate and proof of identity at the entrance",
+    "nl.instructions.prePrinted":
         "Make sure this certificate is printed on A4 (black-and-white allowed)\n\nBring a valid proof of identity to the activity you’re visiting \n\nShow the certificate and proof of identity at the entrance\n\nRequest a new certificate if this one is expired",
+    "nl.instructions.selfPrinted":
+        "Make sure this certificate is printed on A4 (black-and-white allowed)\n\nBring a valid proof of identity to the activity you’re visiting \n\nShow the certificate and proof of identity at the entrance\n\nPrint a new certificate if this one is expired",
     "nl.propertiesLabel": "Your credentials:",
     "nl.validityLabel": "Certificate validity:",
     "nl.title": "Certificate for the Netherlands",

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -57,7 +57,7 @@ export default {
     "nl.issuedOn": "Printed on %{date}",
     "nl.keyId": "Key identifier: %{keyId}",
     "nl.maxValidityExplanation":
-        "* This paper certificate is valid for a maximum of %{days} days. After this you can print a new certificate via [coronacheck.nl/print](https://coronacheck.nl/print) (as long as your vaccination or recovery is still valid). For more information on the requirements and validity of certificates, please visit [rijksoverheid.nl/coronabewijs](https://rijksoverheid.nl/coronabewijs).",
+        "* This paper certificate is valid for a maximum of %{days} days. After this you can print a new certificate via [coronacheck.nl/en/print](https://coronacheck.nl/en/print) (as long as your vaccination or recovery is still valid). For more information on the requirements and validity of certificates, please visit [government.nl/covid-certificate](https://government.nl/covid-certificate).",
     "nl.maxValidity": "Valid for a maximum of %{days} days*",
     instructions: "Instructions",
     "alt.foldInstructions":

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -72,7 +72,7 @@ export default {
     "alt.qr": "QR code",
     questions: "QUESTIONS?",
     questionsContent:
-        "Please find frequently asked questions on [coronacheck.nl](https://coronacheck.nl). You can also send an email to [helpdesk@coronacheck.nl](mailto:helpdesk@coronacheck.nl) or reach us (for free) on 0800-1421",
+        "Please find frequently asked questions on [coronacheck.nl](https://coronacheck.nl). You can also send an email to [helpdesk@coronacheck.nl](mailto:helpdesk@coronacheck.nl) or reach us on 0800-1421 (free of charge)",
     "metadata.title": "Certificate containing QR-code",
     "metadata.author": "Government of the Netherlands",
     "date.months.abbr.1": "JAN",

--- a/src/i18n/nl.js
+++ b/src/i18n/nl.js
@@ -61,7 +61,7 @@ export default {
     "nl.keyId": "Sleutelnummer: %{keyId}",
     "nl.maxValidityExplanation":
         "* Dit papieren bewijs is maximaal %{days} dagen geldig. Hierna kun je een nieuw bewijs printen via [coronacheck.nl/print](https://coronacheck.nl/print) (zolang je vaccinatie of herstel nog geldig is). Kijk op [rijksoverheid.nl/coronabewijs](https://rijksoverheid.nl/coronabewijs) voor meer informatie over de eisen en geldigheid van coronabewijzen.",
-    "nl.maxValidity": "Maixmaal %{days} dagen geldig*",
+    "nl.maxValidity": "Maximaal %{days} dagen geldig*",
     instructions: "Instructies",
     "alt.foldInstructions":
         "Vouwinstructies. Vouw eerst in de breedte doormidden, met de geprinte kant naar buiten. Vouw daarna opnieuw doormidden met deze instructies aan de binnenzijde.",

--- a/src/i18n/nl.js
+++ b/src/i18n/nl.js
@@ -41,8 +41,12 @@ export default {
     "eu.userData.validFrom": "Geldig vanaf",
     "eu.userData.validUntil": "Geldig tot",
     "eu.userData.certificateNumber": "UNIEK CERTIFICAATNUMMER",
-    "nl.instructions":
+    "nl.instructions.test":
+        "Zorg dat dit coronabewijs op A4 is geprint (mag in zwart-wit)\n\nNeem een geldig identiteitsbewijs mee naar de plek die je bezoekt\n\nLaat je coronabewijs en identiteitsbewijs zien bij de ingang",
+    "nl.instructions.prePrinted":
         "Zorg dat dit coronabewijs op A4 is geprint (mag in zwart-wit)\n\nNeem een geldig identiteitsbewijs mee naar de plek die je bezoekt\n\nLaat je coronabewijs en identiteitsbewijs zien bij de ingang\n\nVraag een nieuw bewijs aan als deze is verlopen",
+    "nl.instructions.selfPrinted":
+        "Zorg dat dit coronabewijs op A4 is geprint (mag in zwart-wit)\n\nNeem een geldig identiteitsbewijs mee naar de plek die je bezoekt\n\nLaat je coronabewijs en identiteitsbewijs zien bij de ingang\n\nPrint een nieuw bewijs uit als deze is verlopen",
     "nl.propertiesLabel": "Jouw gegevens:",
     "nl.validityLabel": "Geldigheid bewijs:",
     "nl.title": "Bewijs voor in Nederland",

--- a/src/i18n/nl.js
+++ b/src/i18n/nl.js
@@ -51,7 +51,7 @@ export default {
     "nl.validityLabel": "Geldigheid bewijs:",
     "nl.title": "Bewijs voor in Nederland",
     "nl.intro":
-        "Bezoek je locaties of activiteiten binnen Nederland? Gebruik dan dit coronabewijs.",
+        "Bezoek je plekken of activiteiten binnen Nederland? Gebruik dan dit coronabewijs.",
     "nl.alt.flag": "Nederlandse vlag",
     "nl.qrTitle": "Coronatoegangs-\nbewijs",
     "nl.userData": "Initialen: %{initials}\nGeboortedag: %{dateOfBirth}",

--- a/src/i18n/nl.js
+++ b/src/i18n/nl.js
@@ -71,7 +71,7 @@ export default {
     "alt.qr": "QR-code",
     questions: "VRAGEN?",
     questionsContent:
-        "Bekijk de meestgestelde vragen op [coronacheck.nl](https://coronacheck.nl) of stuur een e-mail naar [helpdesk@coronacheck.nl](mailto:helpdesk@coronacheck.nl) of bel naar 0800-1421 (gratis)",
+        "Bekijk de meestgestelde vragen op [coronacheck.nl](https://coronacheck.nl), stuur een e-mail naar [helpdesk@coronacheck.nl](mailto:helpdesk@coronacheck.nl) of bel naar 0800-1421 (gratis)",
     "metadata.title": "Coronabewijs met QR-code",
     "metadata.author": "Rijksoverheid",
     "date.months.abbr.1": "JAN",

--- a/src/pdf/document.js
+++ b/src/pdf/document.js
@@ -41,6 +41,8 @@ export function createDocument(locale, args) {
     var creator = (args && args.creator) || "CoronaCheck";
     var createdAt =
         (args && args.createdAt && new Date(args.createdAt)) || new Date();
+    var doubleSided = Boolean(args && args.doubleSided);
+    var printMode = Boolean(args && args.printMode);
 
     var pdf = new PDFDocument({
         autoFirstPage: false,
@@ -73,7 +75,7 @@ export function createDocument(locale, args) {
     }
 
     var documentStruct;
-    if (!args.printMode) {
+    if (!printMode) {
         documentStruct = pdf.struct("Document");
         pdf.addStructure(documentStruct);
     }
@@ -88,7 +90,7 @@ export function createDocument(locale, args) {
             throw new Error("Cannot _addPart, document already finalized");
         }
         pageQueue = pageQueue.then(addPage).then(fn);
-        if (args && args.doubleSided && (sides == null || sides % 2)) {
+        if (doubleSided && (sides == null || sides % 2)) {
             pageQueue = pageQueue.then(addPage);
         }
     }
@@ -97,7 +99,7 @@ export function createDocument(locale, args) {
         if (finalized) {
             throw new Error("Cannot addStruct, document already finalized");
         }
-        if (args.printMode) {
+        if (printMode) {
             pdf.addStructure(pdf.struct(type, contents));
         } else {
             documentStruct.add(pdf.struct(type, contents));

--- a/src/pdf/document.js
+++ b/src/pdf/document.js
@@ -161,7 +161,7 @@ export function getDocument(args) {
     });
     addDccCoverPage(doc, args.proofs, args.createdAt);
     args.proofs.forEach(function (proof) {
-        addProofPage(doc, proof, args.createdAt);
+        addProofPage(doc, proof, args.createdAt, { selfPrinted: true });
     });
     return documentToBlob(doc).then(function (blob) {
         return blobToDataURI(blob).then(function (dataURI) {

--- a/src/pdf/proofPage.js
+++ b/src/pdf/proofPage.js
@@ -531,6 +531,7 @@ function structNlDetailsSection(doc, proof, createdAt) {
             size: fontSizeStandard,
             lineGap: 1,
             position: [rightPartLeft, null],
+            width: partWidth,
             emptyLineAfter: true,
         }),
     ];
@@ -545,6 +546,7 @@ function structNlDetailsSection(doc, proof, createdAt) {
                     size: fontSizeStandard,
                     lineGap: 1,
                     position: [rightPartLeft, null],
+                    width: partWidth,
                     emptyLineAfter: true,
                 })
             );
@@ -558,6 +560,7 @@ function structNlDetailsSection(doc, proof, createdAt) {
                 size: fontSizeStandard,
                 lineGap: 1,
                 position: [rightPartLeft, null],
+                width: partWidth,
             }),
             structText(doc, "P", {
                 text: t(doc.locale, "nl.keyId", {
@@ -567,6 +570,7 @@ function structNlDetailsSection(doc, proof, createdAt) {
                 size: fontSizeStandard,
                 lineGap: 1,
                 position: [rightPartLeft, null],
+                width: partWidth,
             })
         );
     }

--- a/src/pdf/proofPage.js
+++ b/src/pdf/proofPage.js
@@ -66,10 +66,13 @@ var fontSizeFooter = 8;
  * @param {import("./document.js").Document} doc
  * @param {import("../types").Proof} proof
  * @param {Date|number} createdAt
- * args.nlPrintIssuedOn and args.nlKeyId are DEPRECATED
+ * @param {Object} [args]
+ * @param {boolean} [args.selfPrinted] - Whether the recipient still needs to print the PDF themselves. Default false.
+ * @param {boolean} [args.nlPrintIssuedOn] - DEPRECATED
+ * @param {string} [args.nlKeyId] - DEPRECATED
  */
-export function addProofPage(doc, proof, createdAt) {
-    var structProof = proof.territory === "nl" ? structNlProof : structEuProof;
+export function addProofPage(doc, proof, createdAt, args) {
+    var selfPrinted = args && args.selfPrinted;
     doc.addPart(function () {
         return qrDataToSvg(
             proof.qr,
@@ -89,17 +92,25 @@ export function addProofPage(doc, proof, createdAt) {
             doc.loadFont("ROSansBold", ROSansWebTextBold);
             doc.addStruct("Art", [
                 structLogoRijksoverheid(doc),
-                structProof(doc, qrSvg, proof, createdAt),
+                proof.territory === "nl"
+                    ? structNlProof(doc, qrSvg, proof, createdAt, selfPrinted)
+                    : structEuProof(doc, qrSvg, proof, createdAt),
             ]);
         });
     });
 }
 
-function structNlProof(doc, qrSvg, proof, createdAt) {
+function structNlProof(doc, qrSvg, proof, createdAt, selfPrinted) {
+    var instructionsVariant = proof.validAtMost25Hours
+        ? "test"
+        : selfPrinted
+        ? "selfPrinted"
+        : "prePrinted";
+
     var instructionsContent = [
         structInstructionsHeading(doc),
         structFoldInstructions(doc),
-        structInstructionsList(doc, "nl.instructions"),
+        structInstructionsList(doc, "nl.instructions." + instructionsVariant),
         structNlQuestionsPanel(doc),
     ];
 


### PR DESCRIPTION
Fix:
* [x] the URLs for the links in the English version of the validity explanation
* [x] situation-specific instructions
* [x] error thrown when optional `args` to `createDocument` were missing
* [x] update Questions? copy
* [x] fix typos
* [x] update title page copy
* [x] validity explanation paragraph width