### PR TITLE
fix: CKVP instructions

### DIFF
--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -2,8 +2,10 @@ export default {
     "eu.instructions":
         "Make sure this certificate is printed on A4 (black-and-white allowed)\n\nBring a valid proof of identity on your travels\n\nShow your certificate at the border, or upon request",
     "eu.validUntil": "This paper certificate is valid until:",
-    "eu.createNew":
-        "After this date you print a new certificate via [coronacheck.nl/en/print](https://coronacheck.nl/en/print)",
+    "eu.createNew.prePrinted":
+        "After this you can call 0800-1421 to request a new certificate.",
+    "eu.createNew.selfPrinted":
+        "After this you can print a new certificate via [coronacheck.nl/en/print](https://coronacheck.nl/en/print).",
     "eu.negativetest.title": "International test certificate",
     "eu.negativetest.qrTitle": "Test certificate",
     "eu.negativetest.propertiesLabel": "Negative test details",

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -62,7 +62,9 @@ export default {
         "Valid from: %{validFrom}\nValid until: %{validUntil}",
     "nl.issuedOn": "Printed on %{date}",
     "nl.keyId": "Key identifier: %{keyId}",
-    "nl.maxValidityExplanation":
+    "nl.maxValidityExplanation.prePrinted":
+        "* This paper certificate is valid for a maximum of %{days} days. After this you can call 0800-1421 to request a new certificate (as long as your vaccination or recovery is still valid). For more information on the requirements and validity of certificates, please visit [government.nl/covid-certificate](https://government.nl/covid-certificate).",
+    "nl.maxValidityExplanation.selfPrinted":
         "* This paper certificate is valid for a maximum of %{days} days. After this you can print a new certificate via [coronacheck.nl/en/print](https://coronacheck.nl/en/print) (as long as your vaccination or recovery is still valid). For more information on the requirements and validity of certificates, please visit [government.nl/covid-certificate](https://government.nl/covid-certificate).",
     "nl.maxValidity": "Valid for a maximum of %{days} days*",
     instructions: "Instructions",

--- a/src/i18n/nl.js
+++ b/src/i18n/nl.js
@@ -2,7 +2,9 @@ export default {
     "eu.instructions":
         "Zorg dat dit coronabewijs op A4 is geprint (mag in zwart-wit)\n\nNeem een geldig identiteitsbewijs mee op reis\n\nLaat het bewijs zien aan de buitenlandse grens of als er in andere landen om gevraagd wordt",
     "eu.validUntil": "Dit papieren bewijs is geldig tot:",
-    "eu.createNew":
+    "eu.createNew.prePrinted":
+        "Daarna kan je bellen naar 0800-1421 om een nieuw bewijs aan te vragen.",
+    "eu.createNew.selfPrinted":
         "Daarna kan je een nieuw bewijs printen via [coronacheck.nl/print](https://coronacheck.nl/print).",
     "eu.negativetest.title": "Internationaal testbewijs",
     "eu.negativetest.qrTitle": "Testbewijs",

--- a/src/i18n/nl.js
+++ b/src/i18n/nl.js
@@ -61,7 +61,9 @@ export default {
         "Geldig vanaf: %{validFrom}\nGeldig tot: %{validUntil}",
     "nl.issuedOn": "Geprint op %{date}",
     "nl.keyId": "Sleutelnummer: %{keyId}",
-    "nl.maxValidityExplanation":
+    "nl.maxValidityExplanation.prePrinted":
+        "* Dit papieren bewijs is maximaal %{days} dagen geldig. Hierna kun je bellen naar 0800-1421 om een nieuw bewijs aan te vragen (zolang je vaccinatie of herstel nog geldig is). Kijk op [rijksoverheid.nl/coronabewijs](https://rijksoverheid.nl/coronabewijs) voor meer informatie over de eisen en geldigheid van coronabewijzen.",
+    "nl.maxValidityExplanation.selfPrinted":
         "* Dit papieren bewijs is maximaal %{days} dagen geldig. Hierna kun je een nieuw bewijs printen via [coronacheck.nl/print](https://coronacheck.nl/print) (zolang je vaccinatie of herstel nog geldig is). Kijk op [rijksoverheid.nl/coronabewijs](https://rijksoverheid.nl/coronabewijs) voor meer informatie over de eisen en geldigheid van coronabewijzen.",
     "nl.maxValidity": "Maximaal %{days} dagen geldig*",
     instructions: "Instructies",

--- a/src/pdf/proofPage.js
+++ b/src/pdf/proofPage.js
@@ -74,6 +74,7 @@ var fontSizeFooter = 8;
  */
 export function addProofPage(doc, proof, createdAt, args) {
     var selfPrinted = args && args.selfPrinted;
+    var structProof = proof.territory === "nl" ? structNlProof : structEuProof;
     doc.addPart(function () {
         return qrDataToSvg(
             proof.qr,
@@ -94,9 +95,7 @@ export function addProofPage(doc, proof, createdAt, args) {
             doc.loadFont("ROSansBold", ROSansWebTextBold);
             doc.addStruct("Art", [
                 structLogoRijksoverheid(doc),
-                proof.territory === "nl"
-                    ? structNlProof(doc, qrSvg, proof, createdAt, selfPrinted)
-                    : structEuProof(doc, qrSvg, proof, createdAt),
+                structProof(doc, qrSvg, proof, createdAt, selfPrinted),
             ]);
         });
     });
@@ -137,7 +136,7 @@ function structNlProof(doc, qrSvg, proof, createdAt, selfPrinted) {
     return doc.pdf.struct("Sect", content);
 }
 
-function structEuProof(doc, qrSvg, proof, createdAt) {
+function structEuProof(doc, qrSvg, proof, createdAt, selfPrinted) {
     var instructionsContent = [
         structInstructionsHeading(doc),
         structFoldInstructions(doc),
@@ -149,7 +148,7 @@ function structEuProof(doc, qrSvg, proof, createdAt) {
     if (proof.eventType === "vaccination") {
         instructionsContent.push(
             structValidUntil(doc, proof.validUntil),
-            structValidUntilInstructions(doc)
+            structEuValidUntilInstructions(doc, selfPrinted)
         );
     }
 
@@ -482,9 +481,12 @@ function structValidUntil(doc, validUntil) {
     ]);
 }
 
-function structValidUntilInstructions(doc) {
+function structEuValidUntilInstructions(doc, selfPrinted) {
     return structText(doc, "P", {
-        text: t(doc.locale, "eu.createNew"),
+        text: t(
+            doc.locale,
+            "eu.createNew." + (selfPrinted ? "selfPrinted" : "prePrinted")
+        ),
         font: "ROSansRegular",
         size: fontSizeStandard,
         position: [rightPartLeft, null],

--- a/src/pdf/proofPage.js
+++ b/src/pdf/proofPage.js
@@ -118,7 +118,7 @@ function structNlProof(doc, qrSvg, proof, createdAt, selfPrinted) {
     var proofContent = [
         structProofTitle(doc, "nl.qrTitle"),
         structNlQrSection(doc, qrSvg),
-        structNlDetailsSection(doc, proof, createdAt),
+        structNlDetailsSection(doc, proof, createdAt, selfPrinted),
     ];
 
     var content = [
@@ -495,7 +495,7 @@ function structEuValidUntilInstructions(doc, selfPrinted) {
     });
 }
 
-function structNlDetailsSection(doc, proof, createdAt) {
+function structNlDetailsSection(doc, proof, createdAt, selfPrinted) {
     var contents = [
         structText(doc, "H2", {
             text: t(doc.locale, "nl.propertiesLabel"),
@@ -543,9 +543,14 @@ function structNlDetailsSection(doc, proof, createdAt) {
         if (!proof.validAtMost25Hours) {
             contents.push(
                 structText(doc, "P", {
-                    text: t(doc.locale, "nl.maxValidityExplanation", {
-                        days: "90",
-                    }),
+                    text: t(
+                        doc.locale,
+                        "nl.maxValidityExplanation." +
+                            (selfPrinted ? "selfPrinted" : "prePrinted"),
+                        {
+                            days: "90",
+                        }
+                    ),
                     font: "ROSansRegular",
                     size: fontSizeStandard,
                     lineGap: 1,


### PR DESCRIPTION
Adjust renewal instructions on both EU and domestic proofs for CKVP (`selfPrinted: false`).