### PR TITLE
fix: structFigure BBox

### DIFF
--- a/src/pdf/proofPage.js
+++ b/src/pdf/proofPage.js
@@ -306,7 +306,7 @@ function structLogoRijksoverheid(doc) {
     var x = pageWidth / 4 - 4.55;
     var y = 0;
     var width = 9.1;
-    var height = 39;
+    var height = 18.2;
     var alt = t(doc.locale, "alt.logoRijksoverheid");
     var image = logoRijksoverheidA5;
     return structFigure(

--- a/src/pdf/struct.js
+++ b/src/pdf/struct.js
@@ -1,6 +1,7 @@
 import { parseMarkdownLinks } from "../util.js";
 
 var dpmm = 72 / 25.4; // dots per mm at 72dpi
+var defaultPageHeight = 297;
 
 /**
  * @param {import("./document").Document} doc
@@ -10,6 +11,7 @@ var dpmm = 72 / 25.4; // dots per mm at 72dpi
  * @param {number} options.y
  * @param {number} options.width
  * @param {number} options.height
+ * @param {number} [options.pageHeight] Defaults to A4
  * @param {() => void} fn
  */
 export function structFigure(doc, options, fn) {
@@ -17,7 +19,8 @@ export function structFigure(doc, options, fn) {
     var y = options.y * dpmm;
     var width = options.width * dpmm;
     var height = options.width * dpmm;
-    var bbox = [x, y, x + width, y + height];
+    var pageHeight = (options.pageHeight || defaultPageHeight) * dpmm;
+    var bbox = [x, pageHeight - y - height, x + width, pageHeight - y];
     var figure = doc.pdf.struct("Figure", { alt: options.alt }, fn);
     figure.dictionary.data.BBox = bbox;
     figure.dictionary.data.A = doc.pdf.ref({

--- a/src/pdf/struct.js
+++ b/src/pdf/struct.js
@@ -18,7 +18,7 @@ export function structFigure(doc, options, fn) {
     var x = options.x * dpmm;
     var y = options.y * dpmm;
     var width = options.width * dpmm;
-    var height = options.width * dpmm;
+    var height = options.height * dpmm;
     var pageHeight = (options.pageHeight || defaultPageHeight) * dpmm;
     var bbox = [x, pageHeight - y - height, x + width, pageHeight - y];
     var figure = doc.pdf.struct("Figure", { alt: options.alt }, fn);
@@ -27,6 +27,8 @@ export function structFigure(doc, options, fn) {
         O: String("Layout"),
         BBox: bbox,
         Placement: String("Block"),
+        Width: width,
+        Height: height,
     });
     figure.dictionary.data.A.end();
     return figure;


### PR DESCRIPTION
The bounding box origin is at the bottom of the page and the coordinates are declared counter-clockwise, i.e. `[left, bottom, right, top]`.